### PR TITLE
Set min_matches equal to max_matches for all dataset configs

### DIFF
--- a/olmoearth_run_data/awf/dataset.json
+++ b/olmoearth_run_data/awf/dataset.json
@@ -61,6 +61,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 12,
+          "min_matches": 12,
           "period_duration": "30d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },

--- a/olmoearth_run_data/ecosystem_type_mapping/dataset.json
+++ b/olmoearth_run_data/ecosystem_type_mapping/dataset.json
@@ -62,6 +62,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 6,
+          "min_matches": 6,
           "period_duration": "30d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },

--- a/olmoearth_run_data/forest_loss_driver/dataset.json
+++ b/olmoearth_run_data/forest_loss_driver/dataset.json
@@ -76,6 +76,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 4,
+          "min_matches": 4,
           "space_mode": "CONTAINS"
         },
         "sort_by": "eo:cloud_cover",
@@ -112,6 +113,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 4,
+          "min_matches": 4,
           "space_mode": "CONTAINS"
         },
         "sort_by": "eo:cloud_cover",

--- a/olmoearth_run_data/lfmc/dataset.json
+++ b/olmoearth_run_data/lfmc/dataset.json
@@ -50,6 +50,7 @@
         },
         "query_config": {
           "max_matches": 12,
+          "min_matches": 12,
           "period_duration": "14d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },
@@ -98,6 +99,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 12,
+          "min_matches": 12,
           "period_duration": "14d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },

--- a/olmoearth_run_data/mangrove/dataset.json
+++ b/olmoearth_run_data/mangrove/dataset.json
@@ -54,6 +54,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 12,
+          "min_matches": 12,
           "period_duration": "30d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },

--- a/olmoearth_run_data/nandi/dataset.json
+++ b/olmoearth_run_data/nandi/dataset.json
@@ -61,6 +61,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 12,
+          "min_matches": 12,
           "period_duration": "30d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },

--- a/olmoearth_run_data/satlas_solar_farm/dataset.json
+++ b/olmoearth_run_data/satlas_solar_farm/dataset.json
@@ -84,6 +84,7 @@
         "name": "rslearn.data_sources.planetary_computer.Sentinel2",
         "query_config": {
           "max_matches": 4,
+          "min_matches": 4,
           "period_duration": "30d",
           "space_mode": "PER_PERIOD_MOSAIC"
         },


### PR DESCRIPTION
As these models need to see all time steps in order to work properly (e.g. all 12 months of data, not less), we set `min_matches` equal to `max_matches`. This effectively means exactly N matches are required.