### PR TITLE
Apply Sentinel1ToDecibels to train/val/test configs

### DIFF
--- a/olmoearth_run_data/lfmc/model.yaml
+++ b/olmoearth_run_data/lfmc/model.yaml
@@ -59,6 +59,9 @@ data:
     default_config:
       patch_size: 32
       transforms:
+        - class_path: rslearn.train.transforms.sentinel1.Sentinel1ToDecibels
+          init_args:
+            selectors: ["sentinel1"]
         - class_path: rslearn.models.olmoearth_pretrain.norm.OlmoEarthNormalize
           init_args:
             band_names:


### PR DESCRIPTION
This matches what is already done for the predict config.

FYI @cmwilhelm 